### PR TITLE
Get correct latest tag

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -53,7 +53,7 @@ python3 -m pip install git+git://github.com/VulcanClimateModeling/fv3config.git@
 
 # installation of gt4py
 git clone git://github.com/VulcanClimateModeling/gt4py.git gt4py
-(cd gt4py/ && git checkout $(git describe --abbrev=0 --tags))
+(cd gt4py/ && git checkout $(git for-each-ref --count=1 --sort=-taggerdate --format '%(tag)' refs/tags))
 python3 -m pip install "gt4py/[${cuda_version}]"
 python3 -m gt4py.gt_src_manager install
 


### PR DESCRIPTION
Sometimes when we force push to develop, we lose the link to the latest tag. This uses the last tag by date, not by ref.