### PR TITLE
Use GT4PY_TAG to install a version of gt4py

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -54,10 +54,10 @@ python3 -m pip install git+git://github.com/VulcanClimateModeling/fv3config.git@
 # installation of gt4py
 git clone git://github.com/VulcanClimateModeling/gt4py.git gt4py
 cd gt4py
-if [ -z "${GT4PY_TAG}" ]; then
-    GT4PY_TAG=$(git for-each-ref --count=1 --sort=-taggerdate --format '%(tag)' refs/tags)
+if [ -z "${GT4PY_VERSION}" ]; then
+    GT4PY_VERSION=$(git for-each-ref --count=1 --sort=-taggerdate --format '%(tag)' refs/tags)
 fi
-git checkout ${GT4PY_TAG}
+git checkout ${GT4PY_VERSION}
 cd ../
 python3 -m pip install "gt4py/[${cuda_version}]"
 python3 -m gt4py.gt_src_manager install


### PR DESCRIPTION
If the environment variable GT4PY_TAG is set, use that, otherwise look for the latest tag as before