### PR TITLE
Install GridTools2 for GTC

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -104,6 +104,7 @@ git checkout ${GT4PY_VERSION}
 cd ../
 python3 -m pip install "gt4py/[${cuda_version}]"
 python3 -m gt4py.gt_src_manager install
+python3 -m gt4py.gt_src_manager install -m 2
 
 # deactivate virtual environment
 deactivate


### PR DESCRIPTION
This PR modifies the `install.sh` script to install GridTools v2 at build time rather than waiting until run time.